### PR TITLE
Add `sudorandom/fauxrpc`

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ Third-party
 
 Third-party
 * [connectproto](https://github.com/akshayjshah/connectproto) - Customize the default JSON and binary codecs from [Connect-Go](https://github.com/connectrpc/connect-go).
+* [fauxrpc](https://github.com/sudorandom/fauxrpc) - Generate fake implementations of gRPC, gRPC-Web, Connect, and REST services to assist in testing.
 
 ## Kotlin
 


### PR DESCRIPTION
`fauxrpc` is a useful tool for testing Connect services by allowing users to generate fake implementations. It is a very useful tool for not only Connect, but protobuf (and protovalidate) as a whole.

A blog post written by the author: https://kmcd.dev/posts/fauxrpc-protovalidate/