### PR TITLE
Add `sudorandom/example-connect-https`

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ Third-party
 
 Third-party
 * [connectproto](https://github.com/akshayjshah/connectproto) - Customize the default JSON and binary codecs from [Connect-Go](https://github.com/connectrpc/connect-go).
+* [example-connect-https](https://github.com/sudorandom/example-connect-https) - A simple Go example that shows how to run a ConnectRPC server with TLS and how to connect to it with a client. 
 
 ## Kotlin
 


### PR DESCRIPTION
This adds [https://github.com/sudorandom/example-connect-https](https://github.com/sudorandom/example-connect-https) which provides a helpful example of running a Connect Go client and server using HTTPS. Users have asked numerous times in the Buf public slack for an example of using HTTPS and this provides a helpful place to point them.